### PR TITLE
refactor : 회원가입 완료시 302코드 대신 303코드사용

### DIFF
--- a/src/main/java/controller/UserController.java
+++ b/src/main/java/controller/UserController.java
@@ -16,7 +16,7 @@ public class UserController {
         System.out.println("User created: " + user);
 
         // 회원가입 성공 후 리디렉션 응답 설정
-        response.setStatusCode(302); // HTTP 상태 코드 302 설정
+        response.setStatusCode(303); // HTTP 상태 코드 302 설정
         response.setHeader("Location", "/index.html"); // 리디렉션할 페이지 설정
     }
 }


### PR DESCRIPTION
refactor : 회원가입 완료시 302코드 대신 303코드사용

- 302/307: 일시적인 이동(예: 모바일 전용 사이트로 이동하거나 관리 페이지를 표시)
  303: 요청된 페이지에 반환활 콘텐츠가 없거나 혹은 원래 반환할 페이지가 따로 있을 때, 그쪽으로 이동시키려고 사용한다. (예: 로그인 페이지를 사용해 로그인한 후 원래 페이지로 이동하는 경우)
 - 회원가입완료의 경우 303이 더 맞는거 같아서 수정